### PR TITLE
147 tweak favourite journeys scrolling

### DIFF
--- a/frontend/src/layout/FavouriteJourneys.jsx
+++ b/frontend/src/layout/FavouriteJourneys.jsx
@@ -22,14 +22,16 @@ const FavouriteJourneys = () => {
     }, [isAuthenticated])
 
     return (
-        <Card style={{overflowY: "auto", minHeight: 300, maxHeight: 400}}
+        <Card style={{overflowY: "auto", minHeight: 300, maxHeight: 500, padding: 0}}
               variant={"soft"}>
-            <div style={{display: "flex", justifyContent: "flex-start", alignItems: "center", gap: 10}}>
-                <Star color={"warning"}/>
-                <Typography level={"h4"}>Ulubione kontakty</Typography>
+            <div style={{position: "sticky", top: 0, zIndex: 1, backgroundColor: "inherit"}}>
+                <div style={{display: "flex", justifyContent: "flex-start", alignItems: "center", gap: 10, margin: 16}}>
+                    <Star color={"warning"}/>
+                    <Typography level={"h4"}>Ulubione kontakty</Typography>
+                </div>
+                <Divider/>
             </div>
-            <Divider/>
-            <div>
+            <div style={{paddingLeft: 16, paddingRight: 16}}>
                 {favouriteJourneys.map((favouriteJourney, i) => {
                     const finished = favouriteJourney.contactJourney.finished;
                     return <div key={favouriteJourney.id}>


### PR DESCRIPTION
Issue Id #147 

increase max height by 100px,
creating a div for the "Favorite Contacts" header and Divider,
allows scrolling without a div by replacing the padding with margin and adding {position: "sticky", top: 0, zIndex: 1, backgroundColor: "inherit"}

<img width="326" alt="Zrzut ekranu 2024-12-10 o 17 33 51" src="https://github.com/user-attachments/assets/5b1917eb-a694-4126-962a-be12c710b2e7">
<img width="322" alt="Zrzut ekranu 2024-12-10 o 17 35 09" src="https://github.com/user-attachments/assets/4cf021bf-78f8-440e-b533-af78bb5cd217">
