### PR TITLE
#130/add/favourite-journeys-on-mobile

### DIFF
--- a/frontend/src/layout/AppContent.jsx
+++ b/frontend/src/layout/AppContent.jsx
@@ -70,10 +70,10 @@ const AppContent = props => {
                         </Modal>
                     </>}
             </div>
-            {mediumSize ?
+            {mediumSize &&
             <div style={{margin: 10, paddingBottom: 85}}>
                 <FavouriteJourneys/>
-            </div> : null}
+            </div>}
             <Footer/>
         </div>
     );


### PR DESCRIPTION
Adds **favorite journeys on mobile** at the bottom of the page.
Leaves additional space for the **scheduled contacts button** so that it doesn't cover the bottom of the table.
The desktop version of the website remains unchanged.

---
<img width="508" alt="Zrzut ekranu 2024-12-20 o 18 47 04" src="https://github.com/user-attachments/assets/3929f390-577f-44ea-a3dd-8ae3522e22cd" />

---

<img width="507" alt="Zrzut ekranu 2024-12-20 o 18 49 21" src="https://github.com/user-attachments/assets/9b343fb7-bad5-4858-970a-bca90ff18d85" />

---

<img width="1512" alt="Zrzut ekranu 2024-12-20 o 19 05 40" src="https://github.com/user-attachments/assets/53630843-4525-4a6f-9723-f784dad09f9f" />

---

Closes #130