### PR TITLE
#136/matches background in scheduled contacts dialog with rest of the…

### DIFF
--- a/frontend/src/layout/AppContent.jsx
+++ b/frontend/src/layout/AppContent.jsx
@@ -59,7 +59,7 @@ const AppContent = props => {
                             <NotificationsIcon/>
                         </IconButton>
                         <Modal open={notificationDrawerOpen}>
-                            <ModalDialog sx={{padding: 0, border: "none", backgroundColor: "transparent"}}>
+                            <ModalDialog sx={{padding: 0, border: "none", backgroundColor: "transparent", boxShadow: "none"}}>
                                 <ScheduledContacts/>
                                 <Button color={"neutral"} onClick={() => {
                                     setNotificationDrawerOpen(false)


### PR DESCRIPTION
Get rid of the annoying background in scheduled contacts dialog by adding **boxShadow**: "none" to ModalDialog sx style

<img width="287" alt="Zrzut ekranu 2024-12-22 o 12 10 26" src="https://github.com/user-attachments/assets/a2b2c211-189d-4148-ad38-fa65934f6078" />
<img width="288" alt="Zrzut ekranu 2024-12-22 o 12 10 44" src="https://github.com/user-attachments/assets/ca3b7cac-83e6-49c6-8d96-547f0314daba" />

Closes #136